### PR TITLE
Chore: DatabaseCleaner 기본 키 컬럼 초기화 동적 처리

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,7 @@ val mysqlVersion = "9.1.0"
 val junitPlatformVersion = "1.11.4"
 val guavaVersion = "33.3.0-jre"
 val swaggerVersion = "2.8.3"
+val querydslVersion = "5.1.0"
 
 java {
 	toolchain {
@@ -36,6 +37,9 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-jdbc:$springBootVersion")
 	implementation("org.springframework.boot:spring-boot-starter-validation:$springBootVersion")
 	implementation("org.springframework.boot:spring-boot-starter-web:$springBootVersion")
+
+	implementation("com.querydsl:querydsl-jpa:$querydslVersion")
+	implementation("com.querydsl:querydsl-apt:$querydslVersion")
 
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
 	implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")

--- a/src/main/resources/http/message.http
+++ b/src/main/resources/http/message.http
@@ -1,0 +1,20 @@
+// 메세지 생성
+###
+POST localhost:8080/messages
+Content-Type: application/json
+
+{
+    "content": "Hello, World!"
+}
+###
+
+// 메세지 조회
+@messageId=1
+###
+GET localhost:8080/messages/{{messageId}}
+###
+
+// 전체 메세지 조회
+###
+GET localhost:8080/messages
+###

--- a/src/test/kotlin/com/yourssu/soongpt/common/support/config/DatabaseCleaner.kt
+++ b/src/test/kotlin/com/yourssu/soongpt/common/support/config/DatabaseCleaner.kt
@@ -22,7 +22,7 @@ class DatabaseCleaner : InitializingBean {
         tableNames = em.metamodel.entities.stream()
             .filter({ e -> e.javaType.getAnnotation(Entity::class.java) != null })
             .map(this::extractTableName)
-            .map({ tableName -> CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, tableName) })
+            .map { tableName -> CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, tableName) }
             .collect(Collectors.toList())
     }
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,37 @@
+server:
+  port: 8080
+
+spring:
+  config:
+    activate:
+      on-profile: test
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  cors:
+    allowed-origins: [ http://localhost:3000 ]
+
+
+logging:
+  level:
+    org.springframework: DEBUG
+
+
+springdoc:
+  packages-to-scan: com.yourssu.soongpt
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  swagger-ui:
+    path: /swagger-ui
+    disable-swagger-default-url: true
+    display-request-duration: true
+    operations-sorter: alpha

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  profiles:
+    default: test


### PR DESCRIPTION
#3
## 기능 목록
- [x] information_schema.columns 에서 identity 컬럼 이름과 해당 테이블명을 찾는다.
    - [x] 찾은 컬럼을 1부터 시작하게 초기화한다.
- [x] 테스트에서 실행되는 애플리케이션 설정 파일을 분리한다.
- [x] querydsl 의존성을 추가한다.
- [x] http 파일을 만든다.

## 공유 사항
querydsl에서 truncate 사용은 지원하지 않는다고 해서 native query로 작성했어요. 이 부분 가능한 방안 있으면 남겨주세요.