### PR TITLE
[#81]; docs: API 문서 오타 수정

### DIFF
--- a/src/main/resources/api/course/get_courses_by_code.md
+++ b/src/main/resources/api/course/get_courses_by_code.md
@@ -27,7 +27,7 @@
 | `personeel`    | integer              | No       | Personnel information                              |
 | `scheduleRoom` | string               | No       | Schedule and room information                      |
 | `target`       | string               | No       | Target students for the course                     |
-| `courseTime`   | CourseTimeResponse[] | No       | Array of course schedule and classroom information |
+| `courseTimes`   | CourseTimeResponse[] | No       | Array of course schedule and classroom information |
 
 #### CourseTimeResponse
 
@@ -58,7 +58,7 @@
       "personeel": "30",
       "scheduleRoom": "월 09:00-10:15 (정보과학관 21001-김민수)\n수 09:00-10:15 (정보과학관 21001-김민수)",
       "target": "컴퓨터학부 1,2학년",
-      "courseTime": [
+      "courseTimes": [
         {
           "week": "월",
           "start": "09:00",
@@ -87,7 +87,7 @@
       "personeel": "35",
       "scheduleRoom": "화 13:30-14:45 (정보과학관 21002-이수정)\n목 13:30-14:45 (정보과학관 21002-이수정)",
       "target": "컴퓨터학부 전체",
-      "courseTime": [
+      "courseTimes": [
         {
           "week": "화",
           "start": "13:30",

--- a/src/main/resources/api/timetable/create_timetable.md
+++ b/src/main/resources/api/timetable/create_timetable.md
@@ -134,7 +134,7 @@ Each timetable will have one of the following tags:
             "personeel": 35,
             "scheduleRoom": "수 14:00-16:00 (공학관 2002호-이교수)",
             "target": "컴퓨터 2학년",
-            "courseTime": [
+            "courseTimes": [
               {
                 "week": "수",
                 "start": "14:00",
@@ -157,7 +157,7 @@ Each timetable will have one of the following tags:
             "personeel": 30,
             "scheduleRoom": "금 11:00-13:00 (인문관 301호-박교수)",
             "target": "전체",
-            "courseTime": [
+            "courseTimes": [
               {
                 "week": "금",
                 "start": "11:00",

--- a/src/main/resources/api/timetable/get_timetable_id.md
+++ b/src/main/resources/api/timetable/get_timetable_id.md
@@ -34,7 +34,7 @@
 | `personeel`    | integer              | No       | Personnel information                              |
 | `scheduleRoom` | string               | No       | Schedule and room information                      |
 | `target`       | string               | No       | Target students for the course                     |
-| `courseTime`   | CourseTimeResponse[] | No       | Array of course schedule and classroom information |
+| `courseTimes`   | CourseTimeResponse[] | No       | Array of course schedule and classroom information |
 
 #### CourseTimeResponse
 
@@ -71,7 +71,7 @@
         "personeel": 40,
         "scheduleRoom": "월 19:00-21:00 (공학관 1004호-홍길동)",
         "target": "컴퓨터공학과 2학년",
-        "courseTime": [
+        "courseTimes": [
           {
             "week": "월",
             "start": "19:00",
@@ -94,7 +94,7 @@
         "personeel": 35,
         "scheduleRoom": "화 15:00-17:00 (공학관 1003호-이몽룡)",
         "target": "컴퓨터공학과 2학년",
-        "courseTime": [
+        "courseTimes": [
           {
             "week": "화",
             "start": "15:00",
@@ -117,7 +117,7 @@
         "personeel": 25,
         "scheduleRoom": "수 10:00-12:00 (인문관 201호-성춘향)",
         "target": "전체",
-        "courseTime": [
+        "courseTimes": [
           {
             "week": "수",
             "start": "10:00",


### PR DESCRIPTION
timetable/, course/get_courses_by_code.md의 courseTime을 더 자연스러운 표현인 courseTimes로 수정했습니다.

<!-- 이슈번호를 작성해주세요 -->
Closes #81

## 특이사항
<!-- 구현 시 고려한 사항이나 주의점이 있다면 작성해주세요 -->
- 
