### PR TITLE
[#84]; feat: scheduleRoom 필드 파싱 구현

### DIFF
--- a/src/main/kotlin/com/yourssu/soongpt/domain/courseTime/implement/CourseTime.kt
+++ b/src/main/kotlin/com/yourssu/soongpt/domain/courseTime/implement/CourseTime.kt
@@ -3,7 +3,6 @@ package com.yourssu.soongpt.domain.courseTime.implement
 import com.yourssu.soongpt.domain.courseTime.implement.exception.InvalidCourseTimeException
 
 class CourseTime(
-    val id: Long? = null,
     val week: Week,
     val startTime: Time,
     val endTime: Time,

--- a/src/main/kotlin/com/yourssu/soongpt/domain/courseTime/implement/CourseTimes.kt
+++ b/src/main/kotlin/com/yourssu/soongpt/domain/courseTime/implement/CourseTimes.kt
@@ -1,0 +1,62 @@
+package com.yourssu.soongpt.domain.courseTime.implement
+
+import com.yourssu.soongpt.domain.courseTime.implement.exception.InvalidParseFormatException
+
+class CourseTimes(
+    private val values: List<CourseTime>
+) {
+    companion object {
+        fun parseScheduleRoom(scheduleRoom: String): CourseTimes {
+            if (scheduleRoom.isBlank()) return CourseTimes(emptyList())
+
+            val courseTimes = scheduleRoom.split("\n")
+                .asSequence()
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+                .flatMap { parseScheduleEntry(it) }
+                .toList()
+
+            return CourseTimes(courseTimes)
+        }
+
+        private fun parseScheduleEntry(entry: String): List<CourseTime> {
+            val pattern = Regex("""([월화수목금토일\s]+)\s+(\d{1,2}:\d{2})-(\d{1,2}:\d{2})\s+\((.+?)\)""")
+            val result = pattern.find(entry.trim()) ?: return emptyList()
+
+            try {
+                val (weeksStr, startTimeStr, endTimeStr, classroomStr) = result.destructured
+                val weeks = weeksStr
+                    .trim()
+                    .split("\\s+".toRegex())
+                    .map { Week.fromName(it) }
+
+                if (weeks.isEmpty()) {
+                    throw InvalidParseFormatException()
+                }
+
+                val startTime = Time.of(startTimeStr)
+                val endTime = Time.of(endTimeStr)
+                val classroom = classroomStr.trim()
+
+                return weeks.map { week ->
+                    CourseTime(
+                        week = week,
+                        startTime = startTime,
+                        endTime = endTime,
+                        classroom = classroom
+                    )
+                }
+            } catch (e: Exception) {
+                throw InvalidParseFormatException();
+            }
+
+
+        }
+    }
+
+    fun toList(): List<CourseTime> = values.toList()
+
+    fun isEmpty(): Boolean = values.isEmpty()
+
+    fun size(): Int = values.size
+}

--- a/src/main/kotlin/com/yourssu/soongpt/domain/courseTime/implement/CourseTimes.kt
+++ b/src/main/kotlin/com/yourssu/soongpt/domain/courseTime/implement/CourseTimes.kt
@@ -6,6 +6,7 @@ class CourseTimes(
     private val values: List<CourseTime>
 ) {
     companion object {
+        private val SCHEDULE_PATTERN = Regex("""([월화수목금토일\s]+)\s+(\d{1,2}:\d{2})-(\d{1,2}:\d{2})\s+\((.+)\)""")
         fun from(scheduleRoom: String): CourseTimes {
             if (scheduleRoom.isBlank()) return CourseTimes(emptyList())
 
@@ -20,8 +21,7 @@ class CourseTimes(
         }
 
         private fun parseScheduleEntry(entry: String): List<CourseTime> {
-            val pattern = Regex("""([월화수목금토일\s]+)\s+(\d{1,2}:\d{2})-(\d{1,2}:\d{2})\s+\((.+)\)""")
-            val result = pattern.find(entry.trim()) ?: return emptyList()
+            val result = SCHEDULE_PATTERN.find(entry.trim()) ?: return emptyList()
 
             try {
                 val (weeksStr, startTimeStr, endTimeStr, classroomStr) = result.destructured
@@ -47,10 +47,8 @@ class CourseTimes(
                     )
                 }
             } catch (e: Exception) {
-                throw InvalidParseFormatException();
+                throw InvalidParseFormatException()
             }
-
-
         }
     }
 

--- a/src/main/kotlin/com/yourssu/soongpt/domain/courseTime/implement/CourseTimes.kt
+++ b/src/main/kotlin/com/yourssu/soongpt/domain/courseTime/implement/CourseTimes.kt
@@ -6,7 +6,7 @@ class CourseTimes(
     private val values: List<CourseTime>
 ) {
     companion object {
-        fun parseScheduleRoom(scheduleRoom: String): CourseTimes {
+        fun from(scheduleRoom: String): CourseTimes {
             if (scheduleRoom.isBlank()) return CourseTimes(emptyList())
 
             val courseTimes = scheduleRoom.split("\n")

--- a/src/main/kotlin/com/yourssu/soongpt/domain/courseTime/implement/CourseTimes.kt
+++ b/src/main/kotlin/com/yourssu/soongpt/domain/courseTime/implement/CourseTimes.kt
@@ -20,7 +20,7 @@ class CourseTimes(
         }
 
         private fun parseScheduleEntry(entry: String): List<CourseTime> {
-            val pattern = Regex("""([월화수목금토일\s]+)\s+(\d{1,2}:\d{2})-(\d{1,2}:\d{2})\s+\((.+?)\)""")
+            val pattern = Regex("""([월화수목금토일\s]+)\s+(\d{1,2}:\d{2})-(\d{1,2}:\d{2})\s+\((.+)\)""")
             val result = pattern.find(entry.trim()) ?: return emptyList()
 
             try {

--- a/src/main/kotlin/com/yourssu/soongpt/domain/courseTime/implement/exception/InvalidParseFormatException.kt
+++ b/src/main/kotlin/com/yourssu/soongpt/domain/courseTime/implement/exception/InvalidParseFormatException.kt
@@ -1,0 +1,5 @@
+package com.yourssu.soongpt.domain.courseTime.implement.exception
+
+import com.yourssu.soongpt.common.handler.BadRequestException
+
+class InvalidParseFormatException : BadRequestException(message = "강의 스케줄 포맷이 올바르지 않습니다.")


### PR DESCRIPTION
<!-- 이슈번호를 작성해주세요 -->
Closes #84 

## 특이사항
<!-- 구현 시 고려한 사항이나 주의점이 있다면 작성해주세요 -->
- CourseTimes 일급 컬렉션 구현으로 파싱 로직을 분산시키지 않게 했습니다. 
- CourseTime에서 사용하지 않는 id 필드를 삭제했습니다.
